### PR TITLE
Operador in também é case-insensitive.

### DIFF
--- a/apostila/VariaveisFatos.rst
+++ b/apostila/VariaveisFatos.rst
@@ -230,14 +230,14 @@ Comparação
 * ``>=`` (maior ou igual)
 * ``=~`` (casamento de regex)
 * ``!~`` (não casamento de regex)
-* ``in`` (contém, sendo que comparação de strings é **case-sensitive**)
+* ``in`` (contém, sendo que comparação de strings é **case-insensitive**)
 
 Exemplo do operador ``in``:
 
 .. code-block:: ruby
 
       'bat' in 'batata' # TRUE
-      'Bat' in 'batata' # FALSE
+      'Bat' in 'batata' # TRUE
       'bat' in ['bat', 'ate', 'logo'] # TRUE
       'bat' in { 'bat' => 'feira', 'ate' => 'fruta'} # TRUE
       'bat' in { 'feira' => 'bat', 'fruta' => 'ate' } # FALSE


### PR DESCRIPTION
De acordo com o docs.puppet.com:  "Comparisons of string values are case insensitive for characters in the US ASCII range. Characters outside this range are case sensitive."

Aparentemente, isto vale inclusive para o operador in. Não sei se o comportamento descrito na apostila seria um bug em versões mais antigas do puppet, ou se os testes foram baseados em uma falha de tradução (o operador in é não transitivo, ele pode procurar strings em arrays e hashes, por exemplo). Eu testei com um comando if usando o puppetlabs-release-pc1-1.0.0-2.el6.noarch / puppet-agent-1.5.2-1.el6.x86_64 no CentOS 6.7.
